### PR TITLE
stm32: CAN Kconfig typo

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -255,7 +255,7 @@ choice
     config STM32_CANBUS_PB8_PB9
         bool "CAN bus (on PB8/PB9)" if LOW_LEVEL_OPTIONS && HAVE_STM32_CANBUS
         select CANSERIAL
-    config STM32_CANBUS_PI8_PH13
+    config STM32_CANBUS_PI9_PH13
         bool "CAN bus (on PI9/PH13)" if LOW_LEVEL_OPTIONS && MACH_STM32F4
         select CANSERIAL
     config STM32_CANBUS_PB5_PB6

--- a/src/stm32/can.c
+++ b/src/stm32/can.c
@@ -27,7 +27,7 @@
  #define GPIO_Rx GPIO('B', 8)
  #define GPIO_Tx GPIO('B', 9)
 #endif
-#if CONFIG_STM32_CANBUS_PI8_PH13
+#if CONFIG_STM32_CANBUS_PI9_PH13
  DECL_CONSTANT_STR("RESERVE_PINS_CAN", "PI9,PH13");
  #define GPIO_Rx GPIO('I', 9)
  #define GPIO_Tx GPIO('H', 13)


### PR DESCRIPTION
Fixed simple typo in the Kconfig and can.c. stm32f4 CAN Pins

Signed-off-by: Oliver Walter <oli1111@web.de>